### PR TITLE
Change Garden/matplotliub installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ python3 -mvenv venv
 . venv/bin/activate
 pip install -U setuptools wheel pip
 pip install -e .
-garden install --app matplotlib
+garden install matplotlib --kivy
 ```
 
 ## Installation instructions on a fresh Ubuntu Server 18.04 system:

--- a/python_guis/gui_tkinter.py
+++ b/python_guis/gui_tkinter.py
@@ -14,7 +14,6 @@ class BeetlePicker(tk.Tk):
     def __init__(self):
         super().__init__()
         self.title("Beetle Picker")
-        self.minsize(1280, 720)
 
         self.filename = ""
         self.image = None


### PR DESCRIPTION
The new method `garden install matplotlib --kivy` installs Kivy support for Matplotlib in the standard package directory within the `venv`.